### PR TITLE
Enable monitoring to work with multiple SDP instances on a single hos…

### DIFF
--- a/scripts/monitor_metrics.py
+++ b/scripts/monitor_metrics.py
@@ -110,6 +110,7 @@ class P4Monitor(object):
         parser.add_argument('-L', '--log', default=default_log_file, help="Default: " + default_log_file)
         parser.add_argument('-i', '--sdp-instance', help="SDP instance")
         parser.add_argument('-m', '--metrics-root', default=metrics_root, help="Metrics directory to use. Default: " + metrics_root)
+        parser.add_argument('-o', '--metrics-file', default=metrics_file, help="Metrics file to use. Default: " + metrics_file)
         parser.add_argument('-v', '--verbosity',
                             nargs='?',
                             const="INFO",
@@ -312,7 +313,7 @@ class P4Monitor(object):
         return lines
 
     def writeMetrics(self, lines):
-        fname = os.path.join(self.options.metrics_root, metrics_file)
+        fname = os.path.join(self.options.metrics_root, self.options.metrics_file)
         self.logger.debug("Writing to metrics file: %s", fname)
         self.logger.debug("Metrics: %s\n", "\n".join(lines))
         tmpfname = fname + ".tmp"

--- a/scripts/monitor_metrics.sh
+++ b/scripts/monitor_metrics.sh
@@ -113,6 +113,9 @@ if [[ $UseSDP -eq 1 ]]; then
         exit 1
     fi
 
+    # Since metrics root is shared, adjust tmp_info_data when using SDP:
+    tmp_info_data="$metrics_root/tmp_info-${SDP_INSTANCE}.dat"
+
     # Load SDP controlled shell environment.
     # shellcheck disable=SC1091
     source /p4/common/bin/p4_vars "$SDP_INSTANCE" ||\
@@ -194,7 +197,11 @@ monitor_license () {
     # Note that sometimes you only get supportExpires - we calculate licenseTimeRemaining in that case
     fname="$metrics_root/p4_license${sdpinst_suffix}-${SERVER_ID}.prom"
     tmpfname="$fname.$$"
-    tmp_license_data="$metrics_root/tmp_license"
+    if [[ $UseSDP -eq 1 ]]; then
+        tmp_license_data="$metrics_root/tmp_license-${SDP_INSTANCE}"
+    else
+        tmp_license_data="$metrics_root/tmp_license"
+    fi
     # Don't update if there is no license for this server, e.g. a replica
     no_license=$(grep -c "Server license: none" "$tmp_info_data")
     # Update every 60 mins
@@ -269,7 +276,11 @@ monitor_filesys () {
     #   filesys.P4ROOT.min=250M (default)
     fname="$metrics_root/p4_filesys${sdpinst_suffix}-${SERVER_ID}.prom"
     tmpfname="$fname.$$"
-    tmp_filesys_data="$metrics_root/tmp_filesys"
+    if [[ $UseSDP -eq 1 ]]; then
+        tmp_filesys_data="$metrics_root/tmp_filesys-${SDP_INSTANCE}"
+    else
+        tmp_filesys_data="$metrics_root/tmp_filesys"
+    fi
     # Update every 60 mins
     [[ ! -f "$tmp_filesys_data" || $(find "$tmp_filesys_data" -mmin +60) ]] || return
     configurables="filesys.depot.min filesys.P4ROOT.min filesys.P4JOURNAL.min filesys.P4LOG.min filesys.TEMP.min"
@@ -380,7 +391,11 @@ monitor_processes () {
     # Monitor metrics summarised by cmd or user
     fname="$metrics_root/p4_monitor${sdpinst_suffix}-${SERVER_ID}.prom"
     tmpfname="$fname.$$"
-    monfile="/tmp/mon.out"
+    if [[ $UseSDP -eq 1 ]]; then
+        monfile="/tmp/mon-${SDP_INSTANCE}.out"
+    else
+        monfile="/tmp/mon.out"
+    fi
 
     $p4 monitor show > "$monfile" 2> /dev/null
     rm -f "$tmpfname"
@@ -553,7 +568,11 @@ monitor_pull () {
 
     fname="$metrics_root/p4_pull${sdpinst_suffix}-${SERVER_ID}.prom"
     tmpfname="$fname.$$"
-    tmp_pull_queue="$metrics_root/pullq.out"
+    if [[ $UseSDP -eq 1 ]]; then
+        tmp_pull_queue="$metrics_root/pullq-${SDP_INSTANCE}.out"
+    else
+        tmp_pull_queue="$metrics_root/pullq.out"
+    fi
     $p4 pull -l > "$tmp_pull_queue" 2> /dev/null 
     rm -f "$tmpfname"
 
@@ -614,7 +633,11 @@ monitor_pull () {
 # ... currentJournalNumberLEOF 0
 # ... currentJournalSequenceLEOF -1
 
-    tmp_pull_stats="$metrics_root/pull-lj.out"
+    if [[ $UseSDP -eq 1 ]]; then
+        tmp_pull_stats="$metrics_root/pull-lj-${SDP_INSTANCE}.out"
+    else
+        tmp_pull_stats="$metrics_root/pull-lj.out"
+    fi
     $p4 -Ztag pull -lj > "$tmp_pull_stats" 2> /dev/null 
 
     replica_jnl_file=$(grep "replicaJournalCounter " "$tmp_pull_stats" | awk '{print $3}' )


### PR DESCRIPTION
We run multiple SDP instances on a shared servers. Some of the temporary/status files in the metrics root directory were getting used by monitor_metrics.py and monitor_metrics.sh scripts leading to confused/incorrect metrics.

This PR addresses those conflicts.
