### PR TITLE
fix: collect lock data when lslocks has null path values

### DIFF
--- a/scripts/monitor_metrics.py
+++ b/scripts/monitor_metrics.py
@@ -200,8 +200,14 @@ class P4Monitor(object):
                         "mode": parts[4], "m": parts[5],
                         "start": parts[6], "end": parts[7],
                         "path": None, "blocker": None}
+            # there's a possibility that both PATH and BLOCKER may be None
+            # we'll have to inspect the length of the parts array & values to determine which value(s) to set
             if len(parts) == 9:
-                lockinfo["blocker"] = parts[8]
+                if parts[8].isdigit():
+                    lockinfo["blocker"] = parts[8]
+                else:
+                    lockinfo["path"] = parts[8]
+            # we have both PATH and BLOCKER values present
             if len(parts) == 10:
                 lockinfo["path"] = parts[8]
                 lockinfo["blocker"] = parts[9]


### PR DESCRIPTION
This PR supports collecting `lslocks` lock data even when path is null. These changes were validated on the following systems:
* CentOS 7.x
* Rocky 8.x

`lslocks` output from Rocky 8.x
```
lslocks -J -o +BLOCKER
{
   "locks": [
      {"command": "p4d_1_bin", "pid": "2013551", "type": "FLOCK", "size": null, "mode": "WRITE", "m": "0", "start": "0", "end": "0", "path": null, "blocker": "123"}
   ]
}
```

`lslocks` output on CentOS 7.x
```
COMMAND           PID  TYPE SIZE MODE  M      START        END PATH BLOCKER
p4d_1_bin       48134 FLOCK   0B WRITE 0          0          0        123
```

sample output in `/p4/1/logs/monitor_metrics.log`
```
2024-01-22 04:27:01 pid 10458, user , cmd , table None, blocked by pid 689, user svc-account1, cmd sync, args -q --parallel threads=4,min=1,minsize=1 //...@5554459
DEBUG 2024-01-22 04:27:01,891 monitor_metrics.py 318: Writing to metrics file: /depotdata/metrics/locks.prom
DEBUG 2024-01-22 04:27:01,891 monitor_metrics.py 319: Metrics: # HELP p4_locks_db_read Database read locks
# TYPE p4_locks_db_read gauge
p4_locks_db_read{serverid="server_id_value",sdpinst="1"} 0
# HELP p4_locks_db_write Database write locks
# TYPE p4_locks_db_write gauge
p4_locks_db_write{serverid="server_id_value",sdpinst="1"} 0
# HELP p4_locks_cliententity_read clientEntity read locks
# TYPE p4_locks_cliententity_read gauge
p4_locks_cliententity_read{serverid="server_id_value",sdpinst="1"} 0
# HELP p4_locks_cliententity_write clientEntity write locks
# TYPE p4_locks_cliententity_write gauge
p4_locks_cliententity_write{serverid="server_id_value",sdpinst="1"} 0
# HELP p4_locks_meta_read meta db read locks
# TYPE p4_locks_meta_read gauge
p4_locks_meta_read{serverid="server_id_value",sdpinst="1"} 0
# HELP p4_locks_meta_write meta db write locks
# TYPE p4_locks_meta_write gauge
p4_locks_meta_write{serverid="server_id_value",sdpinst="1"} 0
# HELP p4_locks_cmds_blocked cmds blocked by locks
# TYPE p4_locks_cmds_blocked gauge
p4_locks_cmds_blocked{serverid="server_id_value",sdpinst="1"} 1
```
