### PR TITLE
tolerate empty errors.csv files when gathering metrics

### DIFF
--- a/scripts/monitor_metrics.sh
+++ b/scripts/monitor_metrics.sh
@@ -547,6 +547,7 @@ monitor_errors () {
     # ... f_name f_severity
     line=$($p4 logschema "$ver" | grep -B1 f_severity | head -1)
     if ! [[ $line =~ f_field ]]; then
+        touch "$fname"
         return
     fi
     indSeverity=$(echo "$line" | awk '{print $3}')


### PR DESCRIPTION
At times the errors.csv file will be empty when gathering metrics. This causes the associated *.prom file to not get a timestamp update which has the knock-on affect of some alters thinking the metrics gathering is not working properly.

This patch simply touches the appropriated *.prom file every time metrics are gathered.