### PR TITLE
Fix: Prevent silent failure when using a custom local_bin_dir

### DIFF
--- a/scripts/install_node.sh
+++ b/scripts/install_node.sh
@@ -93,6 +93,12 @@ if [[ $(id -u) -ne 0 ]]; then
    exit 1
 fi
 
+# Check if local_bin_dir exists
+if [[ ! -d "$local_bin_dir" ]]; then
+    echo "Error: Directory $local_bin_dir does not exist. Please create it before running this script."
+    exit 1
+fi
+
 wget=$(which wget)
 [[ $? -eq 0 ]] || bail "Failed to find wget in path"
 

--- a/scripts/install_p4prom.sh
+++ b/scripts/install_p4prom.sh
@@ -113,6 +113,12 @@ if [[ $(id -u) -ne 0 ]]; then
    exit 1
 fi
 
+# Check if the local_bin_dir exists
+if [[ ! -d "$local_bin_dir" ]]; then
+    echo "Error: Directory $local_bin_dir does not exist. Please create it before running this script."
+    exit 1
+fi
+
 command -v wget 2> /dev/null || bail "Failed to find wget in path"
 
 if command -v getenforce > /dev/null; then


### PR DESCRIPTION
Previously, if a user specified a custom local_bin_dir that didn't exist, the script appeared to run successfully but failed silently - files were not installed in the expected location.

This update ensures that install_p4prom.sh and install_node.sh explicitly check if local_bin_dir exists after parsing arguments. If the directory is missing, the script now exits with an error instead of failing silently.