### PR TITLE
Fix monitorCheckpoint: reset per-file state and stop at most recent complete checkpoint

### DIFF
--- a/cmd/p4metrics/p4metrics.go
+++ b/cmd/p4metrics/p4metrics.go
@@ -1733,22 +1733,22 @@ func (p4m *P4MonitorMetrics) monitorCheckpoint() {
 	var startLines, endLines []string
 	var startLine, endLine string
 	for _, f := range files { // Process in order of most recent first
+		startLine = ""
+		endLine = ""
+
 		cmd := fmt.Sprintf("head %s", f)
 		p = script.NewPipe().WithStderr(errbuf)
 		startLines, err = p.Exec(cmd).MatchRegexp(reStart).Slice()
 		if len(startLines) == 1 && err == nil {
-			ckpLog = f
 			startLine = startLines[0]
 		}
 
-		cmd = fmt.Sprintf("tail %s", ckpLog)
+		cmd = fmt.Sprintf("tail %s", f)
 		p = script.NewPipe().WithStderr(errbuf)
 		endLines, err = p.Exec(cmd).Slice()
 		if len(endLines) > 0 && err == nil {
-			ckpLog = f
 			for _, line := range endLines {
 				if reEnd.MatchString(line) {
-					ckpLog = f
 					endLine = line
 					break
 				}
@@ -1763,9 +1763,9 @@ func (p4m *P4MonitorMetrics) monitorCheckpoint() {
 				}
 			}
 		}
-		// If we found both start and end lines in this file, we're done
 		if startLine != "" && endLine != "" {
-			break
+			ckpLog = f
+			break // Found a complete checkpoint in this file; stop at the most recent one.
 		}
 	}
 	if startLine == "" || endLine == "" {


### PR DESCRIPTION
Three related bugs in the checkpoint log scanning loop caused
p4_sdp_checkpoint_log_time to report the mtime of the oldest complete
checkpoint file rather than the most recent one, triggering false
P4CheckpointNotTaken alerts on installations with multiple rotated
checkpoint log files.

Bug 1: startLine and endLine were never reset between loop iterations.
Values from one file could contaminate the next file's evaluation,
causing a false positive match across two different files.

Bug 2: The tail command used ckpLog (set in the previous iteration)
instead of f, so the end-line search always read the wrong file on
the second and subsequent iterations.

Bug 3: ckpLog was assigned prematurely on partial matches rather than
only when a complete checkpoint (both Start and End lines present) was
confirmed in the same file.

Fix: reset startLine and endLine at the top of each iteration, use f
consistently for both head and tail commands, and defer ckpLog
assignment to the break condition.